### PR TITLE
add HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,4 +162,7 @@ EXPOSE 80 443
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/http3/Dockerfile
+++ b/http3/Dockerfile
@@ -198,5 +198,8 @@ EXPOSE 80/tcp 443/tcp 443/udp
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]
 

--- a/ip/ip2location/Dockerfile
+++ b/ip/ip2location/Dockerfile
@@ -195,4 +195,7 @@ EXPOSE 80 443
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/ip/ip2region/Dockerfile
+++ b/ip/ip2region/Dockerfile
@@ -171,4 +171,7 @@ EXPOSE 80 443
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/ip/ip2region/Dockerfile-v1
+++ b/ip/ip2region/Dockerfile-v1
@@ -167,4 +167,7 @@ EXPOSE 80 443
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+  
 CMD ["nginx", "-g", "daemon off;"]

--- a/quic/Dockerfile
+++ b/quic/Dockerfile
@@ -206,4 +206,7 @@ EXPOSE 80/tcp 443/tcp 443/udp
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -164,4 +164,7 @@ EXPOSE 80 443
 
 STOPSIGNAL SIGQUIT
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
容器增加健康检查，nc -z 命令来检查 NGINX 是否侦听 localhost 的 80 端口。如果命令成功，则输出空，并返回零退出代码，否则将输出错误消息并返回非零退出代码